### PR TITLE
Fix problem when days is not shown after DST change

### DIFF
--- a/lib/time_utils.dart
+++ b/lib/time_utils.dart
@@ -30,7 +30,7 @@ class TimeUtils {
   /// Obtains the first day of the current week,
   /// based on user's current day
   static DateTime firstDayOfTheWeek(DateTime today) {
-    return today.subtract(new Duration(
+    return safeSubtract(today, Duration(
         days: (today.weekday % DateTime.daysPerWeek),
         hours: today.hour,
         minutes: today.minute,
@@ -40,12 +40,38 @@ class TimeUtils {
   }
 
   static DateTime firstDayOfCalendar(DateTime day, int columnsAmount) {
-    return day.subtract(Duration(days: (DateTime.daysPerWeek * (columnsAmount - 1))));
+    return safeSubtract(day, Duration(days: (DateTime.daysPerWeek * (columnsAmount - 1))));
   }
 
   /// Sets a DateTime hours/minutes/seconds/microseconds/milliseconds to 0
   static DateTime removeTime(DateTime dateTime) {
     return DateTime(dateTime.year, dateTime.month, dateTime.day);
+  }
+
+  /// Returns date without timezone info (UTC format)
+  static DateTime removeTZ(DateTime dateTime) {
+    return DateTime.utc(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute,
+        dateTime.second, dateTime.millisecond, dateTime.millisecond);
+  }
+
+  /// Returns date with local timezone
+  static DateTime addTZ(DateTime dateTime) {
+    return DateTime(dateTime.year, dateTime.month, dateTime.day, dateTime.hour, dateTime.minute,
+        dateTime.second, dateTime.millisecond, dateTime.microsecond);
+  }
+
+  /// Subtract duration without timezone.
+  /// That prevents from problems with time shift if DST changed
+  static DateTime safeSubtract(DateTime dateTime, Duration duration) {
+    DateTime add = removeTZ(dateTime).subtract(duration);
+    return addTZ(add);
+  }
+
+  /// Add duration without timezone.
+  /// That prevents from problems with time shift if DST changed
+  static DateTime safeAdd(DateTime dateTime, Duration duration) {
+    DateTime add = removeTZ(dateTime).add(duration);
+    return addTZ(add);
   }
 
   /// Creates a list of [DateTime], including all days between [startDate] and [finishDate]
@@ -56,7 +82,7 @@ class TimeUtils {
     DateTime aux = startDate;
     do {
       datesList.add(aux);
-      aux = aux.add(Duration(days: 1));
+      aux = safeAdd(aux, Duration(days: 1));
     } while (finishDate.millisecondsSinceEpoch >= aux.millisecondsSinceEpoch);
 
     return datesList;

--- a/test/time_utils_test.dart
+++ b/test/time_utils_test.dart
@@ -64,11 +64,25 @@ void main() {
       expect(datesBetween, contains(initialDate));
     });
 
-    test('should fail assertion if initial date is after finisih date', () {
+    test('should fail assertion if initial date is after finish date', () {
       expect(
           () => TimeUtils.datesBetween(
               DateTime.now(), DateTime.now().subtract(Duration(days: 7))),
           throwsAssertionError);
+    });
+
+    test('No duplicated dates in DST change', () {
+      List<DateTime> datesBetween = TimeUtils.datesBetween(DateTime(2020, 10, 23), DateTime(2020, 10, 27));
+      Set<int> set = datesBetween.map((date) => date.day).toSet();
+      expect(set.length, datesBetween.length);
+    });
+
+    test('All dates set to midnight in DST change', () {
+      List<DateTime> datesBetween = TimeUtils.datesBetween(DateTime(2020, 10, 23), DateTime(2020, 10, 27));
+      datesBetween.forEach((date) => expect(date.hour, 0, reason: date.toIso8601String()));
+
+      List<DateTime> datesBetweenSummer = TimeUtils.datesBetween(DateTime(2020, 3, 27), DateTime(2020, 3, 31));
+      datesBetweenSummer.forEach((date) => expect(date.hour, 0, reason: date.toIso8601String()));
     });
   });
 }


### PR DESCRIPTION
I found that previous days is not colored after daylight saving time (DST) change. 
For example, if DST change happens at 25 Oct - all dates before will not be colored.

This happens because  DateTime `subtract() or add()` subtracts exact 24 * 60 * 60 seconds for each day.
And it may come to behavior when subtracting one day from midnight may return same day but with 23:00.

I solved this problem by introducing helper functions `safeAdd()` and `safeSubtract()` which removes TZ (convert to UTC) subtracting then adding TZ back